### PR TITLE
Fix server port environment variable and ESLint globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,8 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      // Enable browser and Node globals so server code passes linting
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ const db = knex({
 db.migrate.latest();
 
 const app = express()
-const port = process.env.port || 3069
+// Use PORT environment variable if supplied (common in hosting platforms)
+const port = process.env.PORT || 3069
 app.use(express.json())
 app.use(cors({
     // "origin" : "http://localhost:5173"
@@ -54,5 +55,3 @@ app.listen(port, () => {console.log("app is running on port", port)})
 
 // console.log("performance: ", performance)
 // console.log("process.env: ", process.env.port)
-// console.log("process.env: ", process.env.password)
-// console.log("process.env: ", process.env.user)


### PR DESCRIPTION
## Summary
- fix environment variable name in server
- add Node globals to ESLint configuration

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856f8035a98832e90362f880f534a63